### PR TITLE
Update executor node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: false
 runs:
-  using: 'node12'
+  using: 'node14'
   main: 'dist/index.js'
 branding:
   icon: 'tag'


### PR DESCRIPTION
Dependencies in v4 no longer support NodeJS 12, so the action needs to be updated accordingly.